### PR TITLE
Toogle fix

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="21" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,15 +4,15 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="jbr-21" />
+        <option name="gradleJvm" value="jbr-17" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/project/resqfood/presentation/MainActivity.kt
+++ b/app/src/main/java/com/project/resqfood/presentation/MainActivity.kt
@@ -188,8 +188,6 @@ class MainActivity : ComponentActivity() {
                         PostScreen {
                             navController.popBackStack()
                         }
-
-
                         composable<NavOnboarding> {
                             Onboarding(navController = navController)
                         }
@@ -200,6 +198,7 @@ class MainActivity : ComponentActivity() {
                     composable<NavListingRestaurant> {
                         ListingRestaurantScreen(restaurantListingViewModel, navController)
                     }
+
                 }
             }
         }

--- a/app/src/main/java/com/project/resqfood/presentation/login/Screens/MainScreen.kt
+++ b/app/src/main/java/com/project/resqfood/presentation/login/Screens/MainScreen.kt
@@ -166,7 +166,7 @@ fun MainScreen(
                                 .padding(horizontal = 16.dp, vertical = 8.dp),
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically
-                        ) {
+                        ) { //toogle fix
                             Text(
                                 text = "Dark Mode",
                                 style = MaterialTheme.typography.bodyLarge

--- a/app/src/main/java/com/project/resqfood/presentation/login/Screens/MainScreen.kt
+++ b/app/src/main/java/com/project/resqfood/presentation/login/Screens/MainScreen.kt
@@ -76,6 +76,7 @@ import kotlinx.coroutines.launch
 import kotlinx.serialization.Serializable
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
+import androidx.compose.ui.graphics.Color
 import com.project.resqfood.presentation.MainActivity
 import timber.log.Timber
 
@@ -157,22 +158,36 @@ fun MainScreen(
                             .padding(16.dp, end = 16.dp, top = 12.dp),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Text(
-                            text = "Dark Mode",
-                            style = MaterialTheme.typography.bodyLarge,
-                            modifier = Modifier.weight(1f)
-                        )
-                        Switch(
-                            checked = MainActivity.isDarkModeEnabled.value,
-                            onCheckedChange = { isChecked ->
-                                MainActivity.isDarkModeEnabled.value = isChecked
-                            },
-                            colors = SwitchDefaults.colors(
-                                checkedThumbColor = MaterialTheme.colorScheme.primary
+                        Spacer(modifier = Modifier.height(24.dp))
+
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = 16.dp, vertical = 8.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween,
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            Text(
+                                text = "Dark Mode",
+                                style = MaterialTheme.typography.bodyLarge
                             )
-                        )
+
+                            Switch(
+                                checked = MainActivity.isDarkModeEnabled.value,
+                                onCheckedChange = { isChecked ->
+                                    MainActivity.isDarkModeEnabled.value = isChecked
+                                },
+                                colors = SwitchDefaults.colors(
+                                    checkedThumbColor = Color(0xFFFFD600),
+                                    checkedTrackColor = Color(0xFFFFD600).copy(alpha = 0.3f),
+                                    uncheckedThumbColor = Color.Gray,
+                                    uncheckedTrackColor = Color.Gray.copy(alpha = 0.3f)
+                                )
+                            )
+                        }
                     }
-                    // Add more items as needed
+
+                        // Add more items as needed
                 }
             }
         },

--- a/app/src/main/java/com/project/resqfood/presentation/login/Screens/MainScreen.kt
+++ b/app/src/main/java/com/project/resqfood/presentation/login/Screens/MainScreen.kt
@@ -2,12 +2,11 @@ package com.project.resqfood.presentation.login.Screens
 
 
 import android.content.Intent
-import android.util.Log
+
 
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedContentTransitionScope
-import androidx.compose.animation.AnimatedContentTransitionScope.SlideDirection.Companion.Down
-import androidx.compose.animation.AnimatedContentTransitionScope.SlideDirection.Companion.Up
+
 import androidx.compose.animation.core.EaseIn
 import androidx.compose.animation.core.EaseOut
 import androidx.compose.animation.core.tween
@@ -166,7 +165,7 @@ fun MainScreen(
                                 .padding(horizontal = 16.dp, vertical = 8.dp),
                             horizontalArrangement = Arrangement.SpaceBetween,
                             verticalAlignment = Alignment.CenterVertically
-                        ) { //toogle fix
+                        ) {
                             Text(
                                 text = "Dark Mode",
                                 style = MaterialTheme.typography.bodyLarge

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 
 accompanistPager = "0.12.0"
-agp = "8.11.1"
+agp = "8.5.1"
 
 
 annotationPlugin = "1.0.1"


### PR DESCRIPTION
Fixes #154 issue
Added a Dark Mode toggle switch to allow users to switch between light and dark themes manually. The toggle is visually aligned beside the label and designed using Material Design standards with a yellow highlight in active state.
Now it looks fine.

